### PR TITLE
Add ability to set fasterer version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ENV REVIEWDOG_VERSION v0.9.17
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN apk add --update --no-cache build-base git
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ $REVIEWDOG_VERSION
-RUN gem install -N fasterer
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ With `reporter: github-pr-review` a comment is added to the Pull Request Convers
 
 **Required**. Must be in form of `github_token: ${{ secrets.github_token }}`'.
 
+### `fasterer_version`
+
+Optional. Set fasterer version. Possible values:
+* empty or omit: install latest version
+* `gemfile`: install version from Gemfile (`Gemfile.lock` should be presented, otherwise it will fallback to latest bundler version)
+* version (e.g. `0.10.0`): install said version
+
 ### `tool_name`
 
 Optional. Tool name to use for reviewdog reporter. Useful when running multiple

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,8 @@ inputs:
   github_token:
     description: 'GITHUB_TOKEN.'
     required: true
+  fasterer_version:
+    description: 'Fasterer version'
   tool_name:
     description: 'Tool name to use for reviewdog reporter'
     default: 'fasterer'
@@ -21,6 +23,7 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.github_token }}
+    - ${{ inputs.fasterer_version }}
     - ${{ inputs.tool_name }}
     - ${{ inputs.level }}
     - ${{ inputs.reporter }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,41 @@
 #!/bin/sh
 
+version() {
+  if [ -n "$1" ]; then
+    echo "-v $1"
+  fi
+}
+
 cd "$GITHUB_WORKSPACE"
 
 git config --global --add safe.directory $GITHUB_WORKSPACE || exit 1
+
+echo '::group:: Installing fasterer ... https://github.com/DamirSvrtan/fasterer'
+# if 'gemfile' fasterer version selected
+if [ "$INPUT_FASTERER_VERSION" = "gemfile" ]; then
+  # if Gemfile.lock is here
+  if [ -f 'Gemfile.lock' ]; then
+    # grep for fasterer version
+    FASTERER_GEMFILE_VERSION=$(grep -oP '^\s{4}fasterer\s\(\K.*(?=\))' Gemfile.lock)
+
+    # if fasterer version found, then pass it to the gem install
+    # left it empty otherwise, so no version will be passed
+    if [ -n "$FASTERER_GEMFILE_VERSION" ]; then
+      FASTERER_VERSION=$FASTERER_GEMFILE_VERSION
+    else
+      printf "Cannot get the fasterer's version from Gemfile.lock. The latest version will be installed."
+    fi
+  else
+    printf 'Gemfile.lock not found. The latest version will be installed.'
+  fi
+else
+  # set desired fasterer version
+  FASTERER_VERSION=$INPUT_FASTERER_VERSION
+fi
+
+# shellcheck disable=SC2046,SC2086
+gem install -N fasterer $(version $FASTERER_VERSION)
+echo '::endgroup::'
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 


### PR DESCRIPTION
Hi! Thank you for a pretty GitHub Action 🐶

I would suggest adding an option to specify the version to be used as well as the following actions.

- <https://github.com/reviewdog/action-rubocop#rubocop_version>
- <https://github.com/reviewdog/action-reek#reek_version>
- <https://github.com/reviewdog/action-brakeman#brakeman_version>

Please check my changes and merge them if you like it. Thanks!
